### PR TITLE
Handle sequence names with uppercase characters

### DIFF
--- a/sequences_generator.sql
+++ b/sequences_generator.sql
@@ -7,7 +7,7 @@ $$
             SELECT d.refobjid::regclass as schema, a.attname as field, seq.sequence_name
             FROM pg_depend d
                  INNER JOIN pg_attribute a ON a.attrelid = d.refobjid AND a.attnum = d.refobjsubid
-                 INNER JOIN information_schema.sequences as seq ON d.objid = seq.sequence_name::regclass
+                 INNER JOIN information_schema.sequences as seq ON d.objid = ('"' || seq.sequence_schema || '"."' || seq.sequence_name || '"')::regclass
             WHERE d.refobjsubid > 0
               AND d.classid = 'pg_class'::regclass
         )

--- a/sequences_generator.sql
+++ b/sequences_generator.sql
@@ -14,8 +14,8 @@ $$
             LOOP
                 RAISE NOTICE 'RAISE NOTICE ''[START] %'';', row;
                 RAISE NOTICE 'CREATE SEQUENCE IF NOT EXISTS % OWNED BY %.%;', row.sequence_name, row.schema, row.field;
-                RAISE NOTICE 'PERFORM setval(''%'', (SELECT COALESCE(max(%), 0) + 1 FROM %));', row.sequence_name, row.field, row.schema;
-                RAISE NOTICE 'ALTER TABLE % ALTER COLUMN % SET DEFAULT nextVal(''%'');', row.schema, row.field, row.sequence_name;
+                RAISE NOTICE 'PERFORM setval(''"%"'', (SELECT COALESCE(max(%), 0) + 1 FROM %));', row.sequence_name, row.field, row.schema;
+                RAISE NOTICE 'ALTER TABLE % ALTER COLUMN % SET DEFAULT nextVal(''"%"'');', row.schema, row.field, row.sequence_name;
             END LOOP;
         RAISE NOTICE 'RAISE NOTICE ''[DONE]'';';
     END


### PR DESCRIPTION
Currently, the sequences_generator.sql will throw an error if you have any sequences with uppercase characters.

This is happening because of the way PostgreSQL deals with identifiers and how the information_schema.sequences catalog represents sequences.

In PostgreSQL, when you refer to a table or column name in double quotes, it becomes case-sensitive. Without double quotes, PostgreSQL interprets the name in lowercase.

I updated the query's join condition between pg_depend and information_schema.sequences to account for potential uppercase schema and sequence names. The concatenation of seq.sequence_schema and seq.sequence_name with double quotes ensures that the resulting sequence identifier is treated as case-sensitive.




